### PR TITLE
Server side label selector feature

### DIFF
--- a/plugins/kubernetes-api/ts/kubernetesApiGlobals.ts
+++ b/plugins/kubernetes-api/ts/kubernetesApiGlobals.ts
@@ -18,5 +18,4 @@ module KubernetesAPI {
   export var OS_API_VERSION = 'v1';
   export var K8S_EXT_VERSION = 'v1beta1';
 
-  export var labelFilterTextSeparator = ",";
 }

--- a/plugins/kubernetes-api/ts/kubernetesApiHelpers.ts
+++ b/plugins/kubernetes-api/ts/kubernetesApiHelpers.ts
@@ -269,16 +269,6 @@ module KubernetesAPI {
   }
 
   /**
-   * Filter a collection by label
-   **/
-  export function filterByLabel(objects: Array<any>, labelSelector: LabelMap) {
-    var matches = (<any>_).matches(labelSelector);
-    return _.filter(objects, (object) => {
-      return matches(getLabels(object));
-    });
-  }
-
-  /**
    * Returns a fully scoped name with the namespace/kind, suitable to use as a key in maps
    **/
   export function fullName(entity) {

--- a/plugins/kubernetes-api/ts/kubernetesApiHelpers.ts
+++ b/plugins/kubernetes-api/ts/kubernetesApiHelpers.ts
@@ -326,18 +326,6 @@ module KubernetesAPI {
   };
 
   /**
-   * Returns the labels text string using the <code>key1=value1,key2=value2,....</code> format
-   */
-  export function labelsToString(labels, seperatorText = labelFilterTextSeparator) {
-    var answer = "";
-    angular.forEach(labels, (value, key) => {
-      var separator = answer ? seperatorText : "";
-      answer += separator + key + "=" + value;
-    });
-    return answer;
-  }
-
-  /**
    * Returns true if the current status of the pod is running
    */
   export function isRunning(podCurrentState) {
@@ -345,25 +333,6 @@ module KubernetesAPI {
     if (status) {
       var lower = status.toLowerCase();
       return lower.startsWith("run");
-    } else {
-      return false;
-    }
-  }
-
-  /**
-   * Returns true if the labels object has all of the key/value pairs from the selector
-   */
-  export function selectorMatches(selector, labels) {
-    if (angular.isObject(labels)) {
-      var answer = true;
-      var count = 0;
-      angular.forEach(selector, (value, key) => {
-        count++;
-        if (answer && labels[key] !== value) {
-          answer = false;
-        }
-      });
-      return answer && count > 0;
     } else {
       return false;
     }

--- a/plugins/kubernetes-api/ts/kubernetesApiInterfaces.ts
+++ b/plugins/kubernetes-api/ts/kubernetesApiInterfaces.ts
@@ -173,7 +173,7 @@ module KubernetesAPI {
     kind?: string;
     namespace?: string;
     apiVersion?: string;
-    labelSelector?: LabelMap;
+    labelSelector?: string;
     object?: any;
     success?: (objs: any[]) => void;
     error?: (err: any) => void;
@@ -192,10 +192,6 @@ module KubernetesAPI {
     [uid: string]: any;
   }
 
-  export interface LabelMap {
-    [name: string]: string;
-  }
-
   export interface Collection {
     wsURL: string;
     restURL: string;
@@ -203,8 +199,8 @@ module KubernetesAPI {
     kind: string;
     connected: boolean;
     connect();
-    get(cb: (data: any[]) => void, labelSelector?: LabelMap): void;
-    watch(cb: (data: any[]) => void, labelSelector?: LabelMap): (data: any[]) => void;
+    get(cb: (data: any[]) => void): void;
+    watch(cb: (data: any[]) => void): (data: any[]) => void;
     unwatch(cb: (data: any[]) => void): void;
     put(item: any, cb: (data: any) => void, error?: (err: any) => void): void;
     delete(item: any, cb: (data: any) => void, error?: (err: any) => void): void;


### PR DESCRIPTION
Allow to pass a labelSelector when creating a client.
    
The labelSelector is the string as used by the kubectl/oc `-l`
cli arg.
    
Example: create projects client
    
```
const projects_client = this.K8SClientFactory.create({
    kind: KubernetesAPI.WatchTypes.PROJECTS,
    labelSelector: "environment=dev"
});
```
    
Ref ENTESB-14539 and hawtio/hawtio-online#64